### PR TITLE
- basic configuration for adding videos to firestore

### DIFF
--- a/src/screens/AddVideo/AddVideo.component.tsx
+++ b/src/screens/AddVideo/AddVideo.component.tsx
@@ -6,16 +6,16 @@ export type Level = 'beginner' | 'intermediate' | 'advanced' | '';
 export type Rating = 1 | 2 | 3 | 4 | 5 | null;
 interface OwnProps {
   addVideo(video: AddVideoFormUrl): void;
-  videoIsDuplicate: boolean;
-  setVideoIsDuplicateToFalse: () => void;
+  onCancel: boolean;
+  onConfirm: () => void;
   videoAdded: boolean;
   clearMessage: () => void;
 }
 
 const AddVideoComponent: FC<OwnProps> = ({
   addVideo,
-  videoIsDuplicate,
-  setVideoIsDuplicateToFalse,
+  onCancel,
+  onConfirm,
   videoAdded,
   clearMessage,
 }) => {
@@ -27,8 +27,8 @@ const AddVideoComponent: FC<OwnProps> = ({
           <AddVideoFormik
             // onSubmit={(values) => addVideo(values)}
             onSubmit={addVideo}
-            videoIsDuplicate={videoIsDuplicate}
-            setVideoIsDuplicateToFalse={setVideoIsDuplicateToFalse}
+            onCancel={onCancel}
+            onConfirm={onConfirm}
             videoAdded={videoAdded}
             clearMessage={clearMessage}
           />

--- a/src/screens/AddVideo/AddVideo.component.tsx
+++ b/src/screens/AddVideo/AddVideo.component.tsx
@@ -6,15 +6,25 @@ export type Level = 'beginner' | 'intermediate' | 'advanced' | '';
 export type Rating = 1 | 2 | 3 | 4 | 5 | null;
 interface OwnProps {
   addVideo(video: AddVideoFormUrl): void;
+  videoIsDuplicate: boolean;
+  setVideoIsDuplicateToFalse: () => void;
 }
 
-const AddVideoComponent: FC<OwnProps> = ({ addVideo }) => {
+const AddVideoComponent: FC<OwnProps> = ({
+  addVideo,
+  videoIsDuplicate,
+  setVideoIsDuplicateToFalse,
+}) => {
   return (
     <Container>
       <Grid container>
         <Grid item sm={2} md={3}></Grid>
         <Grid direction="column" item xs={12} sm={8} md={6}>
-          <AddVideoFormik onSubmit={(values) => addVideo(values)} />
+          <AddVideoFormik
+            onSubmit={(values) => addVideo(values)}
+            videoIsDuplicate={videoIsDuplicate}
+            setVideoIsDuplicateToFalse={setVideoIsDuplicateToFalse}
+          />
         </Grid>
         <Grid item sm={2} md={3}></Grid>
       </Grid>

--- a/src/screens/AddVideo/AddVideo.component.tsx
+++ b/src/screens/AddVideo/AddVideo.component.tsx
@@ -8,12 +8,16 @@ interface OwnProps {
   addVideo(video: AddVideoFormUrl): void;
   videoIsDuplicate: boolean;
   setVideoIsDuplicateToFalse: () => void;
+  videoAdded: boolean;
+  clearMessage: () => void;
 }
 
 const AddVideoComponent: FC<OwnProps> = ({
   addVideo,
   videoIsDuplicate,
   setVideoIsDuplicateToFalse,
+  videoAdded,
+  clearMessage,
 }) => {
   return (
     <Container>
@@ -21,9 +25,12 @@ const AddVideoComponent: FC<OwnProps> = ({
         <Grid item sm={2} md={3}></Grid>
         <Grid direction="column" item xs={12} sm={8} md={6}>
           <AddVideoFormik
-            onSubmit={(values) => addVideo(values)}
+            // onSubmit={(values) => addVideo(values)}
+            onSubmit={addVideo}
             videoIsDuplicate={videoIsDuplicate}
             setVideoIsDuplicateToFalse={setVideoIsDuplicateToFalse}
+            videoAdded={videoAdded}
+            clearMessage={clearMessage}
           />
         </Grid>
         <Grid item sm={2} md={3}></Grid>

--- a/src/screens/AddVideo/AddVideo.component.tsx
+++ b/src/screens/AddVideo/AddVideo.component.tsx
@@ -6,16 +6,16 @@ export type Level = 'beginner' | 'intermediate' | 'advanced' | '';
 export type Rating = 1 | 2 | 3 | 4 | 5 | null;
 interface OwnProps {
   addVideo(video: AddVideoFormUrl): void;
-  onCancel: boolean;
-  onConfirm: () => void;
+  videoIsDuplicate: boolean;
+  onCancel: () => void;
   videoAdded: boolean;
   clearMessage: () => void;
 }
 
 const AddVideoComponent: FC<OwnProps> = ({
   addVideo,
+  videoIsDuplicate,
   onCancel,
-  onConfirm,
   videoAdded,
   clearMessage,
 }) => {
@@ -27,8 +27,8 @@ const AddVideoComponent: FC<OwnProps> = ({
           <AddVideoFormik
             // onSubmit={(values) => addVideo(values)}
             onSubmit={addVideo}
+            videoIsDuplicate={videoIsDuplicate}
             onCancel={onCancel}
-            onConfirm={onConfirm}
             videoAdded={videoAdded}
             clearMessage={clearMessage}
           />

--- a/src/screens/AddVideo/AddVideoFormik/index.tsx
+++ b/src/screens/AddVideo/AddVideoFormik/index.tsx
@@ -31,16 +31,16 @@ export interface AddVideoFormUrl {
 
 interface OwnProps {
   onSubmit(values: AddVideoFormUrl): void;
-  videoIsDuplicate: boolean;
-  setVideoIsDuplicateToFalse: () => void;
+  onCancel: boolean;
+  onConfirm: () => void;
   videoAdded: boolean;
   clearMessage: () => void;
 }
 
 const AddVideoFormik: FC<OwnProps> = ({
   onSubmit,
-  videoIsDuplicate,
-  setVideoIsDuplicateToFalse,
+  onCancel,
+  onConfirm,
   videoAdded,
   clearMessage,
 }) => {
@@ -101,7 +101,7 @@ const AddVideoFormik: FC<OwnProps> = ({
               <Field name="rating" as={FormRatings} />
             </Box>
 
-            {videoIsDuplicate ? (
+            {onCancel ? (
               <Box display="flex" justifyContent="center">
                 <WarningTypography>Video Already Exists</WarningTypography>
               </Box>
@@ -123,7 +123,7 @@ const AddVideoFormik: FC<OwnProps> = ({
                 type="button"
                 onClick={() => {
                   resetForm();
-                  setVideoIsDuplicateToFalse();
+                  onConfirm();
                 }}>
                 Cancel
               </Button>

--- a/src/screens/AddVideo/AddVideoFormik/index.tsx
+++ b/src/screens/AddVideo/AddVideoFormik/index.tsx
@@ -31,16 +31,16 @@ export interface AddVideoFormUrl {
 
 interface OwnProps {
   onSubmit(values: AddVideoFormUrl): void;
-  onCancel: boolean;
-  onConfirm: () => void;
+  videoIsDuplicate: boolean;
+  onCancel: () => void;
   videoAdded: boolean;
   clearMessage: () => void;
 }
 
 const AddVideoFormik: FC<OwnProps> = ({
   onSubmit,
+  videoIsDuplicate,
   onCancel,
-  onConfirm,
   videoAdded,
   clearMessage,
 }) => {
@@ -101,7 +101,7 @@ const AddVideoFormik: FC<OwnProps> = ({
               <Field name="rating" as={FormRatings} />
             </Box>
 
-            {onCancel ? (
+            {videoIsDuplicate ? (
               <Box display="flex" justifyContent="center">
                 <WarningTypography>Video Already Exists</WarningTypography>
               </Box>
@@ -123,7 +123,7 @@ const AddVideoFormik: FC<OwnProps> = ({
                 type="button"
                 onClick={() => {
                   resetForm();
-                  onConfirm();
+                  onCancel();
                 }}>
                 Cancel
               </Button>

--- a/src/screens/AddVideo/AddVideoFormik/index.tsx
+++ b/src/screens/AddVideo/AddVideoFormik/index.tsx
@@ -16,7 +16,7 @@ const addVideoSchema = yup.object().shape({
   youTubeLink: yup
     .string()
     .matches(
-      /^(?:https?:\/\/)?(?:youtu\.be\/|(?:www\.|m\.)?youtube\.com\/(?:watch|v|embed)(?:\.php)?(?:\?.*v=|\/))([a-zA-Z0-9\-_]+)/,
+      /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/gi,
       'Enter correct url!'
     )
     .required('Please enter website'),
@@ -33,13 +33,23 @@ interface OwnProps {
   onSubmit(values: AddVideoFormUrl): void;
   videoIsDuplicate: boolean;
   setVideoIsDuplicateToFalse: () => void;
+  videoAdded: boolean;
+  clearMessage: () => void;
 }
 
 const AddVideoFormik: FC<OwnProps> = ({
   onSubmit,
   videoIsDuplicate,
   setVideoIsDuplicateToFalse,
+  videoAdded,
+  clearMessage,
 }) => {
+  const initialValues: AddVideoFormUrl = {
+    youTubeLink: '',
+    level: '',
+    rating: null,
+  };
+
   return (
     <div>
       <Box paddingTop={4} />
@@ -55,12 +65,11 @@ const AddVideoFormik: FC<OwnProps> = ({
       <Box paddingTop={2} />
 
       <Formik
-        initialValues={{
-          youTubeLink: '',
-          level: '',
-          rating: null,
+        initialValues={initialValues}
+        onSubmit={(values, { resetForm }) => {
+          onSubmit(values);
+          resetForm();
         }}
-        onSubmit={onSubmit}
         validationSchema={addVideoSchema}>
         {({ isValid, resetForm }) => (
           <Form>
@@ -70,6 +79,7 @@ const AddVideoFormik: FC<OwnProps> = ({
               placeholder="https://www.youtube.com/watch?v=fldJek9xDoQ"
               component={TextField}
               fullWidth
+              onKeyUp={clearMessage}
             />
 
             <FormControl>
@@ -90,9 +100,16 @@ const AddVideoFormik: FC<OwnProps> = ({
             <Box display="flex" justifyContent="center">
               <Field name="rating" as={FormRatings} />
             </Box>
+
             {videoIsDuplicate ? (
               <Box display="flex" justifyContent="center">
                 <WarningTypography>Video Already Exists</WarningTypography>
+              </Box>
+            ) : null}
+
+            {videoAdded ? (
+              <Box display="flex" justifyContent="center">
+                <Typography>Video Added to your Favourites</Typography>
               </Box>
             ) : null}
 

--- a/src/screens/AddVideo/AddVideoFormik/index.tsx
+++ b/src/screens/AddVideo/AddVideoFormik/index.tsx
@@ -7,6 +7,7 @@ import { Button, ButtonGroup, Typography } from '@material-ui/core';
 import { Grid, Box } from '@material-ui/core';
 import InputLabel from '@material-ui/core/InputLabel';
 import { Select } from 'formik-material-ui';
+import { WarningTypography } from './styled';
 // @ts-ignore
 import FormRatings from 'form-ratings';
 import { Level, Rating } from '../AddVideo.component';
@@ -30,9 +31,15 @@ export interface AddVideoFormUrl {
 
 interface OwnProps {
   onSubmit(values: AddVideoFormUrl): void;
+  videoIsDuplicate: boolean;
+  setVideoIsDuplicateToFalse: () => void;
 }
 
-const AddVideoFormik: FC<OwnProps> = ({ onSubmit }) => {
+const AddVideoFormik: FC<OwnProps> = ({
+  onSubmit,
+  videoIsDuplicate,
+  setVideoIsDuplicateToFalse,
+}) => {
   return (
     <div>
       <Box paddingTop={4} />
@@ -83,6 +90,11 @@ const AddVideoFormik: FC<OwnProps> = ({ onSubmit }) => {
             <Box display="flex" justifyContent="center">
               <Field name="rating" as={FormRatings} />
             </Box>
+            {videoIsDuplicate ? (
+              <Box display="flex" justifyContent="center">
+                <WarningTypography>Video Already Exists</WarningTypography>
+              </Box>
+            ) : null}
 
             <Box paddingTop={5} />
             <ButtonGroup fullWidth variant={'text'}>
@@ -90,7 +102,12 @@ const AddVideoFormik: FC<OwnProps> = ({ onSubmit }) => {
                 Submit
               </Button>
 
-              <Button type="button" onClick={() => resetForm()}>
+              <Button
+                type="button"
+                onClick={() => {
+                  resetForm();
+                  setVideoIsDuplicateToFalse();
+                }}>
                 Cancel
               </Button>
             </ButtonGroup>

--- a/src/screens/AddVideo/AddVideoFormik/styled.ts
+++ b/src/screens/AddVideo/AddVideoFormik/styled.ts
@@ -1,0 +1,8 @@
+import { styled } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
+import theme from '../../../styles';
+
+export const WarningTypography = styled(Typography)({
+  color: theme.palette.error.main,
+  fontWeight: 'bold',
+});

--- a/src/screens/AddVideo/index.tsx
+++ b/src/screens/AddVideo/index.tsx
@@ -40,8 +40,8 @@ const AddVideo = () => {
   return (
     <AddVideoComponent
       addVideo={addVideo}
-      videoIsDuplicate={videoIsDuplicate}
-      setVideoIsDuplicateToFalse={setVideoIsDuplicateToFalse}
+      onCancel={videoIsDuplicate}
+      onConfirm={setVideoIsDuplicateToFalse}
       videoAdded={videoAdded}
       clearMessage={clearMessage}
     />

--- a/src/screens/AddVideo/index.tsx
+++ b/src/screens/AddVideo/index.tsx
@@ -40,8 +40,8 @@ const AddVideo = () => {
   return (
     <AddVideoComponent
       addVideo={addVideo}
-      onCancel={videoIsDuplicate}
-      onConfirm={setVideoIsDuplicateToFalse}
+      videoIsDuplicate={videoIsDuplicate}
+      onCancel={setVideoIsDuplicateToFalse}
       videoAdded={videoAdded}
       clearMessage={clearMessage}
     />

--- a/src/screens/AddVideo/index.tsx
+++ b/src/screens/AddVideo/index.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import AddVideoComponent, { Level } from './AddVideo.component';
-import { youTubeConfig } from '../../config';
+import React, { useState } from 'react';
+import AddVideoComponent from './AddVideo.component';
 import { AddVideoFormUrl } from './AddVideoFormik';
 import { useSelector } from 'react-redux';
 import { userSelectors } from '../../redux/user';
 import fireApi from '../../services/firebase';
 
 const AddVideo = () => {
-  const [videoObject, setVideoObject] = useState<Object>({});
   const [videoIsDuplicate, setVideoIsDuplicate] = useState<boolean>(false);
+  const [videoAdded, setVideoAdded] = useState<boolean>(false);
   const userId = useSelector(userSelectors.userId);
-  const axios = require('axios');
   const getVideoId = require('get-video-id');
 
-  useEffect(() => {
-    fireApi.addToDb('videos', videoObject);
-  }, [videoObject]);
+  const clearMessage = () => {
+    setVideoAdded(false);
+    setVideoIsDuplicate(false);
+  };
 
   const setVideoIsDuplicateToTrue = () => {
     setVideoIsDuplicate(true);
@@ -25,67 +24,17 @@ const AddVideo = () => {
     setVideoIsDuplicate(false);
   };
 
-  const youTubeApiCall = (
-    videoId: string,
-    level: Level,
-    rating: number | null
-    //i thought about using an AddVideoUrl type here
-    //as well, but I would have to create a new object
-    //in the addVideo function: first I need to
-    //manipulate the youTubeLink string and get its id.
-    //Then i can can create a new object and pass it
-    //to the apiCall. Given this circumstance, I
-    //think that keeping the arguments as they are
-    //makes the code more readable (we know immediately that
-    //the formik values where manipulated before being
-    //passed further). I am open to critism, though! :P
-  ) => {
-    axios
-      .get('https://www.googleapis.com/youtube/v3/videos', {
-        params: {
-          part: 'contentDetails, snippet',
-
-          // part: 'snippet',
-          id: videoId,
-          key: youTubeConfig.apiKey,
-        },
-      })
-      .then(function (response: any) {
-        const videoObject = {
-          id: response.data.items[0].id,
-          title: response.data.items[0].snippet.title,
-          imgDefault: response.data.items[0].snippet.thumbnails.default.url,
-          imgMedium: response.data.items[0].snippet.thumbnails.medium.url,
-          imgBig: response.data.items[0].snippet.thumbnails.high.url,
-          duration: response.data.items[0].contentDetails.duration,
-          level: level,
-          rating: rating,
-          user: userId,
-        };
-        setVideoObject(videoObject);
-      })
-      .catch(function (error: any) {
-        console.log(error);
-      });
-  };
-
   const addVideo = (video: AddVideoFormUrl) => {
     const videoId = getVideoId(video.youTubeLink).id;
-    const videoCollection = fireApi.getCollectionFromDb('videos');
-    videoCollection
-      .where('id', '==', videoId)
-      .get()
-      .then(function (querySnapshot) {
-        if (querySnapshot.empty) {
-          setVideoIsDuplicateToFalse();
-          youTubeApiCall(videoId, video.level, video.rating);
-        } else {
-          setVideoIsDuplicateToTrue();
-        }
-      })
-      .catch(function (error) {
-        console.log('Error getting documents: ', error);
-      });
+    fireApi.checkIfVideoExists(videoId).then((result) => {
+      if (result) {
+        setVideoIsDuplicateToFalse();
+        setVideoAdded(true);
+        fireApi.addVideoToDb(videoId, video, userId);
+      } else {
+        setVideoIsDuplicateToTrue();
+      }
+    });
   };
 
   return (
@@ -93,6 +42,8 @@ const AddVideo = () => {
       addVideo={addVideo}
       videoIsDuplicate={videoIsDuplicate}
       setVideoIsDuplicateToFalse={setVideoIsDuplicateToFalse}
+      videoAdded={videoAdded}
+      clearMessage={clearMessage}
     />
   );
 };

--- a/src/services/firebase.tsx
+++ b/src/services/firebase.tsx
@@ -1,12 +1,17 @@
 import firebase from 'firebase';
+import 'firebase/firestore';
 import { firebaseConfig } from '../config';
 
 const fire = firebase.initializeApp(firebaseConfig);
+const db = firebase.firestore();
 const fireAuth = fire.auth();
 
 const fireApi = {
   //Auth API
-
+  addToDb: (collectionName: string, addedItem: object) =>
+    db.collection(collectionName).add(addedItem),
+  getCollectionFromDb: (collectionName: string) =>
+    db.collection(collectionName),
   doCreateUserWithEmailAndPassword: (email: string, password: string) =>
     fireAuth.createUserWithEmailAndPassword(email, password),
 

--- a/src/services/firebase.tsx
+++ b/src/services/firebase.tsx
@@ -1,6 +1,8 @@
 import firebase from 'firebase';
 import 'firebase/firestore';
 import { firebaseConfig } from '../config';
+import youTubeApi from './youTube';
+import { AddVideoFormUrl } from '../screens/AddVideo/AddVideoFormik';
 
 const fire = firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
@@ -8,10 +10,21 @@ const fireAuth = fire.auth();
 
 const fireApi = {
   //Auth API
-  addToDb: (collectionName: string, addedItem: object) =>
-    db.collection(collectionName).add(addedItem),
-  getCollectionFromDb: (collectionName: string) =>
-    db.collection(collectionName),
+  checkIfVideoExists: (videoId: string) =>
+    db
+      .collection('videos')
+      .where('id', '==', videoId)
+      .get()
+      .then((querySnapshot) => querySnapshot.empty),
+  addVideoToDb: (videoId: string, video: AddVideoFormUrl, userId: string) =>
+    youTubeApi.getVideoInfo(videoId).then((youTubeData) => {
+      db.collection('videos').add({
+        ...youTubeData,
+        rating: video.rating,
+        level: video.level,
+        user: userId,
+      });
+    }),
   doCreateUserWithEmailAndPassword: (email: string, password: string) =>
     fireAuth.createUserWithEmailAndPassword(email, password),
 

--- a/src/services/youTube.tsx
+++ b/src/services/youTube.tsx
@@ -1,0 +1,37 @@
+import { youTubeConfig } from '../config';
+
+interface YouTubeInfoData {
+  id: string;
+  title: string;
+  imgDefault: string;
+  imgMedium: string;
+  imgBig: string;
+  duration: string;
+}
+
+const axios = require('axios');
+const youTubeApi = {
+  getVideoInfo: (videoId: string): Promise<YouTubeInfoData> => {
+    return axios
+      .get('https://www.googleapis.com/youtube/v3/videos', {
+        params: {
+          part: 'contentDetails, snippet',
+          id: videoId,
+          key: youTubeConfig.apiKey,
+        },
+      })
+      .then((response: any) => ({
+        id: response.data.items[0].id,
+        title: response.data.items[0].snippet.title,
+        imgDefault: response.data.items[0].snippet.thumbnails.default.url,
+        imgMedium: response.data.items[0].snippet.thumbnails.medium.url,
+        imgBig: response.data.items[0].snippet.thumbnails.high.url,
+        duration: response.data.items[0].contentDetails.duration,
+      }))
+      .catch(function (error: any) {
+        console.log(error);
+      });
+  },
+};
+
+export default youTubeApi;


### PR DESCRIPTION
(https://firebase.google.com/docs/firestore/quickstart)
- so far I only created a collection (videos) as in the instructions above
- maybe it makes sense to explicity define the document identifier instead of having a randomly generated code as explained here (the doc identifier could be the video id). let me know: https://firebase.google.com/docs/firestore/manage-data/add-data

- before adding a video, I check if the video exists already and show a warning. this can and probably should be changed: if the video already exists (added by someone else), we can show a massage such as "video added to your collection" (it will not be added to the backend as a new video, because it already exists), but the user property will be modified, so that the video is now linked both to the original uploader and the new one. For example I could change the videoObject like so: instead of userId we would have "originalUploaderId" and add a new category: likedBy: [originalUploaderId, newGuyThatTriedToUploadTheSameVideo, someGuyThatLikedTheVideo, etc]

TO BE DONE:
- redux's store will take it's video list values from firestore